### PR TITLE
商品情報削除機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
   # ログインしていないユーザーはログインページに促す
   before_action :authenticate_user!, except: [:index, :show]
-  before_action :set_item, only: [:show, :edit, :update]
+  before_action :set_item, only: [:show, :edit, :update, :destroy]
   
   def index
     @items = Item.order('created_at DESC')
@@ -38,6 +38,15 @@ class ItemsController < ApplicationController
     end
   end
 
+  def destroy
+    if @item.user_id == current_user.id
+      @item.destroy
+      redirect_to root_path
+    else
+      redirect_to root_path
+    end
+  end
+
 
   private
 
@@ -47,6 +56,5 @@ class ItemsController < ApplicationController
   
   def set_item
     @item = Item.find(params[:id])
-  
   end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -41,10 +41,8 @@ class ItemsController < ApplicationController
   def destroy
     if @item.user_id == current_user.id
       @item.destroy
-      redirect_to root_path
-    else
-      redirect_to root_path
     end
+    redirect_to root_path
   end
 
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -24,7 +24,7 @@
     <% if current_user.id == @item.user_id %> 
       <%= link_to "商品の編集", edit_item_path(@item), method: :get, class: "item-red-btn" %>
       <p class="or-text">or</p>
-      <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
+      <%= link_to "削除", item_path(@item) , method: :delete, class:"item-destroy" %>
     <%# 未購入品でない場合には、売り切れを表示 %>
     <% else %>
       <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,6 @@ Rails.application.routes.draw do
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
    root to: 'items#index'
    resources :items do
-    resources :orders, only: [:index, :create, :edit,:update]
+    resources :orders, only: [:index, :create, :edit,:update,:destroy]
    end
 end


### PR DESCRIPTION
# What
 商品削除機能の作成
# Why
　商品削除機能を実装するため
ログイン状態の出品者のみ、詳細ページの削除ボタンを押すと、出品した商品を削除できる動画(https://gyazo.com/dc3f1f0fe23e58091b9b9c4d904e28d9)
